### PR TITLE
refactor components and enable storybook themes

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -15,6 +15,12 @@ const preview: Preview = {
       // 'off' - skip a11y checks entirely
       test: "todo",
     },
+    darkMode: {
+      darkClass: "night",
+      lightClass: "winter",
+      classTarget: "html",
+      stylePreview: true,
+    },
   },
 };
 

--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -4,7 +4,7 @@
   import Breadcrumbs from "@/components/Breadcrumbs.vue";
   import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
   import { Button } from "@/components/ui/button";
-  import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+  import { Dropdown } from "@/components/ui/Dropdown";
   import { NavigationMenu, NavigationMenuItem, NavigationMenuList, navigationMenuTriggerStyle } from "@/components/ui/navigation-menu";
   import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
   import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -146,8 +146,8 @@
             </div>
           </div>
 
-          <DropdownMenu>
-            <DropdownMenuTrigger :as-child="true">
+          <Dropdown placement="end">
+            <template #trigger>
               <Button variant="ghost" size="icon" class="relative size-10 w-auto rounded-box-full p-1 focus-within:ring-2 focus-within:ring-primary">
                 <Avatar class="size-8 overflow-hidden rounded-box-full">
                   <AvatarImage v-if="auth.user.avatar" :src="auth.user.avatar" :alt="auth.user.name" />
@@ -156,11 +156,9 @@
                   </AvatarFallback>
                 </Avatar>
               </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" class="w-56">
-              <UserMenuContent :user="auth.user" />
-            </DropdownMenuContent>
-          </DropdownMenu>
+            </template>
+            <UserMenuContent :user="auth.user" />
+          </Dropdown>
         </div>
       </div>
     </div>

--- a/resources/js/components/NavUser.vue
+++ b/resources/js/components/NavUser.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import UserInfo from "@/components/UserInfo.vue";
-  import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+  import { Dropdown } from "@/components/ui/Dropdown";
   import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@/components/ui/sidebar";
   import { type User } from "@/types";
   import { usePage } from "@inertiajs/vue3";
@@ -15,22 +15,15 @@
 <template>
   <SidebarMenu>
     <SidebarMenuItem>
-      <DropdownMenu>
-        <DropdownMenuTrigger as-child>
+      <Dropdown placement="end">
+        <template #trigger>
           <SidebarMenuButton size="lg" class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground">
             <UserInfo :user="user" />
             <ChevronsUpDown class="ml-auto size-4" />
           </SidebarMenuButton>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          class="w-(--reka-dropdown-menu-trigger-width) min-w-56 rounded-lg"
-          :side="isMobile ? 'bottom' : state === 'collapsed' ? 'left' : 'bottom'"
-          align="end"
-          :side-offset="4"
-        >
-          <UserMenuContent :user="user" />
-        </DropdownMenuContent>
-      </DropdownMenu>
+        </template>
+        <UserMenuContent :user="user" />
+      </Dropdown>
     </SidebarMenuItem>
   </SidebarMenu>
 </template>

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import UserInfo from "@/components/UserInfo.vue";
-  import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } from "@/components/ui/dropdown-menu";
   import type { User } from "@/types";
   import { Link, router } from "@inertiajs/vue3";
   import { LogOut, Settings } from "lucide-vue-next";
@@ -17,25 +16,22 @@
 </script>
 
 <template>
-  <DropdownMenuLabel class="p-0 font-normal">
-    <div class="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-      <UserInfo :user="user" :show-email="true" />
-    </div>
-  </DropdownMenuLabel>
-  <DropdownMenuSeparator />
-  <DropdownMenuGroup>
-    <DropdownMenuItem :as-child="true">
-      <Link class="block w-full" :href="route('profile.edit')" prefetch as="button">
-        <Settings class="mr-2 h-4 w-4" />
-        Settings
-      </Link>
-    </DropdownMenuItem>
-  </DropdownMenuGroup>
-  <DropdownMenuSeparator />
-  <DropdownMenuItem :as-child="true">
-    <Link class="block w-full" method="post" :href="route('logout')" @click="handleLogout" as="button">
-      <LogOut class="mr-2 h-4 w-4" />
+  <li class="p-2">
+    <UserInfo :user="user" :show-email="true" />
+  </li>
+  <li>
+    <hr class="mx-2 my-1 border-base-200" />
+  </li>
+  <li>
+    <Link class="flex w-full items-center gap-2" :href="route('profile.edit')" prefetch as="button">
+      <Settings class="h-4 w-4" />
+      Settings
+    </Link>
+  </li>
+  <li>
+    <Link class="flex w-full items-center gap-2" method="post" :href="route('logout')" @click="handleLogout" as="button">
+      <LogOut class="h-4 w-4" />
       Log out
     </Link>
-  </DropdownMenuItem>
+  </li>
 </template>

--- a/resources/js/components/ui/Card/Card.vue
+++ b/resources/js/components/ui/Card/Card.vue
@@ -6,21 +6,9 @@
   import CardTitle from "./CardTitle.vue";
   import { cn } from "@/lib/utils";
 
-  const props = defineProps<CardVariantProps & { class?: HTMLAttributes["class"] }>();
+  const { variant, style, side, imageFull, size, shadow, class: className } = defineProps<CardVariantProps & { class?: HTMLAttributes["class"] }>();
 
-  const classes = computed(() =>
-    cn(
-      cardVariants({
-        variant: props.variant,
-        style: props.style,
-        side: props.side,
-        imageFull: props.imageFull,
-        size: props.size,
-        shadow: props.shadow,
-      }),
-      props.class,
-    ),
-  );
+  const classes = computed(() => cn(cardVariants({ variant, style, side, imageFull, size, shadow }), className));
 </script>
 
 <template>

--- a/resources/js/components/ui/Tabs/Tabs.vue
+++ b/resources/js/components/ui/Tabs/Tabs.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-  import { provide, ref, watch, computed } from "vue";
+  import { provide, ref, computed } from "vue";
   import { useMotion } from "@vueuse/motion";
   import { tabsVariants } from "./cva";
 

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,32 +1,41 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title inertia>{{ config('app.name', 'Laravel App') }}</title>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title inertia>{{ config('app.name', 'Laravel App') }}</title>
 
-    {{-- Favicons and font preloads --}}
-    <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
-    <link rel="preconnect" href="https://fonts.bunny.net">
-    <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+        {{-- Favicons and font preloads --}}
+        <link rel="icon"
+            href="/favicon.ico"
+            sizes="any">
+        <link rel="icon"
+            href="/favicon.svg"
+            type="image/svg+xml">
+        <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
-    {{-- Server-injected default theme (used by JS for initialization fallback) --}}
-    <script>
-        window.APP_THEME = {!! json_encode($appearance ?? 'system') !!};
-    </script>
+        {{-- Server-injected default theme (used by JS for initialization fallback) --}}
+        <script>
+            window.APP_THEME = {!! json_encode($appearance ?? 'system') !!};
+        </script>
 
-    {{-- Optionally: inline styles to prevent background color flash --}}
-    <style>
-        html { background-color: oklch(1 0 0); }
-        html.dark { background-color: oklch(0.145 0 0); }
-    </style>
+        {{-- Optionally: inline styles to prevent background color flash --}}
+        <style>
+            html {
+                background-color: oklch(1 0 0);
+            }
 
-    @vite(['resources/css/app.css', 'resources/js/app.ts'])
-    @inertiaHead
-</head>
-<body class="font-sans antialiased bg-base-100 text-base-content min-h-screen">
-    @inertia
-</body>
+            html.dark {
+                background-color: oklch(0.145 0 0);
+            }
+        </style>
+
+        @vite(['resources/css/app.css', 'resources/js/app.ts'])
+        @inertiaHead
+    </head>
+    <body class="bg-base-100 text-base-content min-h-screen font-sans antialiased">
+        @inertia
+    </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor Card to destructure props and compute variant classes
- clean up Tabs import list
- enable Storybook dark/light themes for winter and night
- switch AppHeader and NavUser to new Dropdown component for user menus

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Key "vue/script-setup-uses-vars": Could not find "script-setup-uses-vars" in plugin "vue")*
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_6897ae387c7c8323a829cffa6fc210c8